### PR TITLE
Fix grepl for ROIs

### DIFF
--- a/R/connectivity.R
+++ b/R/connectivity.R
@@ -203,7 +203,7 @@ extract_connectivity_df <- function(rois, json){
   a = unlist(strsplit(json,"}"))
   values = data.frame()
   for(roi in rois){
-    b = a[grepl(sprintf("\"%s\"",roi),a)]
+    b = a[grepl(sprintf("\"%s\"",roi),a,fixed=TRUE)]
     if(length(b)){
       c = unlist(strsplit(b,","))
       n = as.numeric(gsub("[^0-9.]", "", c))


### PR DESCRIPTION
Switch to grepl with fixed=TRUE when matching ROI names as some of the ROI names contain brackets. This was causing neuprint_find_neurons to return connections all equal to 0 when the ROI name contained a parenthesis.