### PR TITLE
Connection table fix

### DIFF
--- a/R/connectivity.R
+++ b/R/connectivity.R
@@ -42,7 +42,7 @@ neuprint_get_adjacency_matrix <- function(bodyids, dataset = NULL, all_segments 
 #' @inheritParams neuprint_find_neurons
 #' @param prepost whether to look for partners presynaptic to postsynaptic to the given bodyids
 #' @param progress default FALSE. If TRUE, the API is called separately for each neuron and yuo can asses its progress, if an error is thrown by any one bodyid, that bodyid is ignored
-#' @return a data frame giving partners within an ROI, the connection strength for weights to or from that partner, and the direction, for the given bodyid
+#' @return a data frame giving partners within a set of ROIs, the connection strength for weights to or from that partner, and the direction, for the given bodyid
 #' @seealso \code{\link{neuprint_fetch_custom}}, \code{\link{neuprint_simple_connectivity}}, \code{\link{neuprint_common_connectivity}}
 #' @export
 #' @rdname neuprint_connection_table

--- a/R/connectivity.R
+++ b/R/connectivity.R
@@ -81,7 +81,7 @@ neuprint_connection_table <- function(bodyids, prepost = c("PRE","POST"), roi = 
                    prefixed,
                    prefixed,
                    ifelse(prepost=="POST","a","b"),
-                   ifelse(is.null(roi),"keys(apoc.convert.fromJsonMap(c.roiInfo))",roi),
+                   ifelse(is.null(roi),"keys(apoc.convert.fromJsonMap(c.roiInfo))",paste("['",paste(roi,collapse="','"),"']",sep="")),
                    ifelse(prepost=="POST","bodyid","partner"),
                    ifelse(prepost=="POST","partner","bodyid")
                   )

--- a/R/connectivity.R
+++ b/R/connectivity.R
@@ -88,10 +88,11 @@ neuprint_connection_table <- function(bodyids, prepost = c("PRE","POST"), roi = 
   nc = neuprint_fetch_custom(cypher=cypher, conn = conn)
   ## Filter out the rare cases where PSDs and tbars are in different ROIs (hence post is null)
   nc$data <- nc$data[sapply(nc$data,function(x) !is.null(x[[4]]))]
-  d <-  data.frame(do.call(rbind,lapply(nc$data,unlist)))
+  d <-  data.frame(do.call(rbind,lapply(nc$data,unlist)),stringsAsFactors = FALSE)
   colnames(d) <-  unlist(nc$columns)
-  d$prepost = ifelse(prepost=="PRE",0,1)
-  d = d[order(d$weight,decreasing=TRUE),]
+  d$weight <- as.integer(d$weight)
+  d$prepost <-  ifelse(prepost=="PRE",0,1)
+  d <-  d[order(d$weight,decreasing=TRUE),]
   d[,c("bodyid", "partner", "roi","weight", "prepost")]
 }
 


### PR DESCRIPTION
Redesigned the neuprint_connection_table function, using the ConnectsTo object. This now allows to get connections split by ROI for all ROIs (the default) or the ROIs specified (as a single ROI or a vector of ROIs).