### PR TITLE
Roi connectivity patch

### DIFF
--- a/R/connectivity.R
+++ b/R/connectivity.R
@@ -343,8 +343,10 @@ extract_connectivity_df <- function(rois, json){
   for(roi in rois){
     d <-  data.frame(0,0)
     colnames(d) <- paste0(roi,c(".pre",".post"))
-    b <-  a[startsWith(names(a),paste0(roi,"."))]
-    d[names(b)] <-  b
+    if (!is.null(a)){
+      b <-  a[startsWith(names(a),paste0(roi,"."))]
+      d[names(b)] <-  b
+    }
     values <- cbind(values,d)
   }
   values

--- a/man/neuprint_ROI_connectivity.Rd
+++ b/man/neuprint_ROI_connectivity.Rd
@@ -4,10 +4,24 @@
 \alias{neuprint_ROI_connectivity}
 \title{Get the connectivity between ROIs in a neuPrint dataset}
 \usage{
-neuprint_ROI_connectivity(rois, dataset = NULL, conn = NULL, ...)
+neuprint_ROI_connectivity(
+  rois,
+  cached = FALSE,
+  full = TRUE,
+  statistic = c("weight", "count"),
+  dataset = NULL,
+  conn = NULL,
+  ...
+)
 }
 \arguments{
 \item{rois}{regions of interest for a dataset}
+
+\item{cached}{pull cached results (TRUE) or recalculate the connectivity (FALSE)?}
+
+\item{full}{return all neurons involved (TRUE, the default) or give a ROI summary (FALSE, default behavior if `cached` is TRUE)}
+
+\item{statistic}{either "weight" or count" (default "weight"). Which number to return (see neuprint explorer for details) for summary results (either `full` is FALSE or `cached` is TRUE)}
 
 \item{dataset}{optional, a dataset you want to query. If NULL, the default specified by your R environ file is used. See \code{neuprint_login} for details.}
 


### PR DESCRIPTION
New neuprint_ROI_connectivity with options: 

- `cached` for using the cached summary table
- `full` to return either all neurons involved or a summary
- `statistic` to use either "count" or "weight" (to mimic neuprint explorer)

Note that weights are slighlty lower when we compute them ourselves here. Maybe due to neuprint explorer using an incorrect estimate of total post synaptic sites for the neurons?