### PR TITLE
Add an option to make fixed searches

### DIFF
--- a/R/name.R
+++ b/R/name.R
@@ -132,15 +132,16 @@ neuprint_get_roiInfo <- function(bodyids, dataset = NULL, all_segments = FALSE, 
 #' neuprint_search("AVF1",field = "cellBodyFiber")
 #' }
 #' @seealso \code{\link{neuprint_get_meta}}, \code{\link{neuprint_get_neuron_names}}
-neuprint_search <- function(search, field = "name", meta = TRUE, all_segments = FALSE, dataset = NULL, conn = NULL, ...){
+neuprint_search <- function(search, field = "name", fixed=FALSE, meta = TRUE, all_segments = FALSE, dataset = NULL, conn = NULL, ...){
   if(field=="name"){
     conn = neuprint_login(conn)
     field = neuprint_name_field(conn)
   }
   all_segments.cypher = ifelse(all_segments,"Segment","Neuron")
-  cypher = sprintf("MATCH (n:`%s`) WHERE n.%s=~'%s' RETURN n.bodyId",
+  cypher = sprintf("MATCH (n:`%s`) WHERE n.%s %s '%s' RETURN n.bodyId",
                    all_segments.cypher,
                    field,
+                   ifelse(fixed, "CONTAINS", "=~"),
                    search)
   nc = neuprint_fetch_custom(cypher=cypher, dataset = dataset, ...)
   foundbodyids=unlist(nc$data)


### PR DESCRIPTION
`neuprint_search` used to only take in regular expressions, which can be a bit cumbersome when querying names with brackets and other special characters.
This PR adds a `fixed` option to `neuprint_search`, which when TRUE, makes a literal search (like it's now in neuprint explorer), so that:

```r
neuprint_search("PEN_a(PEN1)",field="type",fixed=TRUE)
```
returns what you would expect, when 

```r
neuprint_search("PEN_a(PEN1)",field="type",fixed=FALSE)
```

returns NULL as it's expecting the brackets to be escaped.

This uses (like neuprint explorer), CONTAINS instead of =~ in the query