### PR TITLE
Use (escaped) double quotes in neuprint_search string

### DIFF
--- a/R/name.R
+++ b/R/name.R
@@ -143,7 +143,7 @@ neuprint_search <- function(search, field = "name", fixed=FALSE, meta = TRUE, al
     field = neuprint_name_field(conn)
   }
   all_segments.cypher = ifelse(all_segments,"Segment","Neuron")
-  cypher = sprintf("MATCH (n:`%s`) WHERE n.%s %s '%s' RETURN n.bodyId",
+  cypher = sprintf("MATCH (n:`%s`) WHERE n.%s %s \\\"%s\\\" RETURN n.bodyId",
                    all_segments.cypher,
                    field,
                    ifelse(fixed, "CONTAINS", "=~"),


### PR DESCRIPTION
It's a fix for the rare cases where the search string contains single quotes (eg "MBON16-like(a'3a)")