### PR TITLE
Add "upstream" and "downstream" fields in extract_connectivity_df

### DIFF
--- a/R/connectivity.R
+++ b/R/connectivity.R
@@ -478,10 +478,10 @@ extract_connectivity_df <- function(rois, json){
   }
   rois <- unique(rois) #this takes care if both the input and output ROIs are same..
   a <- unlist(jsonlite::fromJSON(json))
-  roicols <- c(t(outer(rois, c("pre", "post"), paste, sep=".")))
+  roicols <- c(t(outer(rois, c("pre", "post","upstream","downstream"), paste, sep=".")))
   values <- tibble::as_tibble(as.list(structure(rep(0, length(roicols)), .Names=roicols)))
   for(roi in rois){
-    thisroicols <- paste0(roi,c(".pre",".post"))
+    thisroicols <- paste0(roi,c(".pre",".post",".upstream",".downstream"))
     if (!is.null(a)){
       b <-  a[startsWith(names(a),paste0(roi,"."))]
       values[names(b)] <-  b


### PR DESCRIPTION
This is a non breaking change (fixing a bug on experimental versions of the server), preparing for future releases of neuprint, in which :Neuron nodes and their associated :roiInfo have two extra fields: "upstream" and "downstream". Those fields represent actual synapse counts (rather then presynaptic/postsynaptic terminals), so they match the "weight" value (until now, the total "pre" value was always more than the "weight" value because of polyadic synapses). Making a PR mostly to document the change.