### PR TITLE
Safe field catch

### DIFF
--- a/R/info.R
+++ b/R/info.R
@@ -71,7 +71,6 @@ neuprint_ROIs <- function(superLevel = FALSE, dataset = NULL, fromNeuronFields= 
                                                    "cropped", "instance", "name",
                                                    "size", "type", "cellBodyFiber",
                                                    "somaLocation", "somaRadius","roiInfo"),
-                                limit=200,
                                 negateFields=TRUE,
                                 dataset = NULL, conn = NULL, ...)
   }else{

--- a/R/name.R
+++ b/R/name.R
@@ -370,13 +370,15 @@ neuprint_get_fields <- function(possibleFields = c("bodyId", "pre", "post",
                                                    "cropped", "instance", "name",
                                                    "size", "type", "cellBodyFiber",
                                                    "somaLocation", "somaRadius"),
-                                limit=20,
+                                limit=length(possibleFields)*10,
                                 negateFields=FALSE,
                                 dataset = NULL, conn = NULL, ...){
-  cypher <- sprintf("MATCH (n :`Neuron`) UNWIND KEYS(n) AS k RETURN DISTINCT k AS neuron_fields LIMIT %s",limit)
-  fields <- unlist(neuprint_fetch_custom(cypher=cypher, cache=TRUE, conn=conn, dataset = dataset, ...)$data)
-  if (negateFields){return(fields[!(fields %in% possibleFields)])}
-  return(fields[fields %in% possibleFields])
+
+    cypher <- sprintf("MATCH (n :`Neuron`) UNWIND KEYS(n) AS k RETURN DISTINCT k AS neuron_fields LIMIT %s",limit)
+    fields <- unlist(neuprint_fetch_custom(cypher=cypher, cache=TRUE, conn=conn, dataset = dataset, ...)$data)
+    if (negateFields){fields <- fields[!(fields %in% possibleFields)]} else {fields <- fields[fields %in% possibleFields]}
+
+  return(fields)
 }
 
 # Hidden. Neuprint to our fields translation

--- a/R/name.R
+++ b/R/name.R
@@ -370,7 +370,7 @@ neuprint_get_fields <- function(possibleFields = c("bodyId", "pre", "post",
                                                    "cropped", "instance", "name",
                                                    "size", "type", "cellBodyFiber",
                                                    "somaLocation", "somaRadius"),
-                                limit=length(possibleFields)*10,
+                                limit=50,
                                 negateFields=FALSE,
                                 dataset = NULL, conn = NULL, ...){
 

--- a/R/name.R
+++ b/R/name.R
@@ -370,11 +370,10 @@ neuprint_get_fields <- function(possibleFields = c("bodyId", "pre", "post",
                                                    "cropped", "instance", "name",
                                                    "size", "type", "cellBodyFiber",
                                                    "somaLocation", "somaRadius"),
-                                limit=50,
                                 negateFields=FALSE,
                                 dataset = NULL, conn = NULL, ...){
 
-    cypher <- sprintf("MATCH (n :`Neuron`) UNWIND KEYS(n) AS k RETURN DISTINCT k AS neuron_fields LIMIT %s",limit)
+    cypher <- sprintf("MATCH (n :`Neuron`) UNWIND KEYS(n) AS k RETURN DISTINCT k AS neuron_fields")
     fields <- unlist(neuprint_fetch_custom(cypher=cypher, cache=TRUE, conn=conn, dataset = dataset, ...)$data)
     if (negateFields){fields <- fields[!(fields %in% possibleFields)]} else {fields <- fields[fields %in% possibleFields]}
 

--- a/R/name.R
+++ b/R/name.R
@@ -356,7 +356,6 @@ neuprint_ids <- function(x, mustWork=TRUE, unique=TRUE, fixed=TRUE, conn=NULL, d
 #' @title Get available metadata fields for Neuron nodes
 #' @return a vector of available fields
 #' @param possibleFields : field names to choose from
-#' @param limit : Max length of the server's response (used to speed up the query/adapt to different scenarios)
 #' @param negateFields : Whether to include (FALSE, the default) or exclude \code{possibleFields}
 #' @inheritParams neuprint_ROI_hierarchy
 #' @export

--- a/man/neuprint_get_fields.Rd
+++ b/man/neuprint_get_fields.Rd
@@ -8,7 +8,7 @@ neuprint_get_fields(
   possibleFields = c("bodyId", "pre", "post", "upstream", "downstream", "status",
     "statusLabel", "cropped", "instance", "name", "size", "type", "cellBodyFiber",
     "somaLocation", "somaRadius"),
-  limit = 20,
+  limit = length(possibleFields) * 10,
   negateFields = FALSE,
   dataset = NULL,
   conn = NULL,

--- a/man/neuprint_get_fields.Rd
+++ b/man/neuprint_get_fields.Rd
@@ -8,7 +8,6 @@ neuprint_get_fields(
   possibleFields = c("bodyId", "pre", "post", "upstream", "downstream", "status",
     "statusLabel", "cropped", "instance", "name", "size", "type", "cellBodyFiber",
     "somaLocation", "somaRadius"),
-  limit = length(possibleFields) * 10,
   negateFields = FALSE,
   dataset = NULL,
   conn = NULL,
@@ -17,8 +16,6 @@ neuprint_get_fields(
 }
 \arguments{
 \item{possibleFields}{: field names to choose from}
-
-\item{limit}{: Max length of the server's response (used to speed up the query/adapt to different scenarios)}
 
 \item{negateFields}{: Whether to include (FALSE, the default) or exclude \code{possibleFields}}
 


### PR DESCRIPTION
This PR suppresses the `limit` argument in `neuprint_get_fields`. This argument was intended for speed purposes, which is less of a reason since the results of the function are memoised. Furthermore one could never insure that all parameter names would be caught (the previous default resulted in missing some parameters on some of the datasets).