### PR TITLE
Optimise neuprint_get_roiInfo and neuprint_get_meta

### DIFF
--- a/R/name.R
+++ b/R/name.R
@@ -188,7 +188,7 @@ neuprint_get_roiInfo <- function(bodyids, dataset = NULL, all_segments = FALSE, 
     all_segments
   )
   nc = neuprint_fetch_custom(cypher=cypher, dataset = dataset, conn = conn, ...)
-  lc <-  lapply(nc$data,function(x){cbind(bodyid=x[[1]],as.data.frame(t(unlist(jsonlite::fromJSON(x[[2]])))))})
+  lc <-  lapply(nc$data,function(x){c(list(bodyid=x[[1]]),unlist(jsonlite::parse_json(x[[2]])))})
   d <- dplyr::bind_rows(lc)
   d
 }

--- a/R/name.R
+++ b/R/name.R
@@ -80,6 +80,15 @@ neuprint_get_neuron_names <- function(bodyids, dataset = NULL, all_segments = TR
 neuprint_get_meta <- function(bodyids, dataset = NULL, all_segments = TRUE, conn = NULL,chunk=TRUE,progress=FALSE, ...){
   conn = neuprint_login(conn)
 
+  if(any(duplicated(bodyids))) {
+    ubodyids=unique(bodyids)
+    unames=neuprint_get_meta(bodyids=ubodyids, dataset=dataset,
+                                     conn=conn, all_segments=all_segments,chunk=chunk,progress=progress,...)
+    res=unames[match(bodyids, ubodyids),]
+    return(res)
+  }
+
+
   nP <- length(bodyids)
   if(is.numeric(chunk)) {
     chunksize=chunk
@@ -150,6 +159,14 @@ neuprint_get_meta <- function(bodyids, dataset = NULL, all_segments = TRUE, conn
 #' neuprint_get_roiInfo(c(818983130, 1796818119))
 #' }
 neuprint_get_roiInfo <- function(bodyids, dataset = NULL, all_segments = FALSE, chunk=TRUE,progress=FALSE,conn = NULL, ...){
+  if(any(duplicated(bodyids))) {
+    ubodyids=unique(bodyids)
+    unames=neuprint_get_roiInfo(bodyids=ubodyids, dataset=dataset,
+                             conn=conn, all_segments=all_segments,chunk=chunk,progress=progress,...)
+    res=unames[match(bodyids, ubodyids),]
+    return(res)
+  }
+
   nP <- length(bodyids)
   if(is.numeric(chunk)) {
     chunksize=chunk

--- a/tests/testthat/test-name.R
+++ b/tests/testthat/test-name.R
@@ -29,11 +29,19 @@ test_that("test name searches ", {
                                                                "pre","post","upstream","downstream","cropped",
                                                                "size","cellBodyFiber"))),"soma")
                )
+
+
   id1=da2s$bodyid[1]
   n1=da2s$name[1]
 
+  expect_is(rit <- neuprint_get_roiInfo(id1),'data.frame')
+
   iddup=rep(da2s$bodyid[1], 2)
   ndup=rep(n1, 2)
+
+  expect_is(rit <- neuprint_get_roiInfo(iddup),'data.frame')
+  expect_equal(rit[1,],rit[2,])
+
   # check we can handle missing values
   expect_equivalent(neuprint_get_neuron_names(1), NA_character_)
   # duplicates and missing values


### PR DESCRIPTION
- avoids running through duplicates (à la neuprint_get_names), addresses part of #92 
- more efficient collection into a data.frame for neuprint_get_roiInfo