### PR TITLE
Adding the synonyms field in metadata

### DIFF
--- a/R/connectivity.R
+++ b/R/connectivity.R
@@ -23,10 +23,10 @@
 #' @examples
 #' \donttest{
 #' # these will mostly be axo-axonic connections between DA2 PNs
-#' neuprint_get_adjacency_matrix('DA2_lPN')
+#' neuprint_get_adjacency_matrix('DA2 lPN')
 #'
 #' # rectangular matrix with different in/out neurons
-#' neuprint_get_adjacency_matrix(inputids='DA2_lPN', outputids='DL4_adPN')
+#' neuprint_get_adjacency_matrix(inputids='DA2 lPN', outputids='DL4 adPN')
 #' }
 #' \donttest{
 #' # Note the use of cache=T, which will avoid a subsequent query to the

--- a/R/connectivity.R
+++ b/R/connectivity.R
@@ -673,7 +673,7 @@ neuprint_get_shortest_paths <- function(body_pre,body_post,weightT=5,roi=NULL,by
       dplyr::bind_rows(lapply(d[[4]],function(dT){extract_connectivity_df(roi,dT,"post")}))
     }))
     roiTable[is.na(roiTable)] <- 0
-    connTable <- cbind(connTable,roiTable)
+    connTable <- dplyr::bind_cols(connTable,roiTable)
   }
 
   connTable

--- a/R/connectivity.R
+++ b/R/connectivity.R
@@ -23,10 +23,10 @@
 #' @examples
 #' \donttest{
 #' # these will mostly be axo-axonic connections between DA2 PNs
-#' neuprint_get_adjacency_matrix('DA2 lPN')
+#' neuprint_get_adjacency_matrix('DA2_lPN')
 #'
 #' # rectangular matrix with different in/out neurons
-#' neuprint_get_adjacency_matrix(inputids='DA2 lPN', outputids='DL4 adPN')
+#' neuprint_get_adjacency_matrix(inputids='DA2_lPN', outputids='DL4_adPN')
 #' }
 #' \donttest{
 #' # Note the use of cache=T, which will avoid a subsequent query to the

--- a/R/connectivity.R
+++ b/R/connectivity.R
@@ -552,7 +552,7 @@ neuprint_get_paths <- function(body_pre, body_post, n, weightT=5, roi=NULL, by.r
       dplyr::bind_rows(lapply(d[[4]],function(dT){extract_connectivity_df(roi,dT,"post")}))
     }))
     roiTable[is.na(roiTable)] <- 0
-    connTable <- cbind(connTable,roiTable)
+    connTable <- dplyr::bind_cols(connTable,roiTable)
   }
 
   connTable

--- a/R/dump.R
+++ b/R/dump.R
@@ -52,7 +52,7 @@ neuprint_dump <- function(dir, bodyids = NULL, roi = NULL, preprocess = NULL, co
   # save SWC files
   message("saving SWC files")
   dir.create(file.path(dir, "swc"), showWarnings = FALSE)
-  write.neurons(neurons,dir = file.path(dir, "swc"), format = "swc", files = paste0(bodyid,".swc"), Force = TRUE)
+  write.neurons(neurons,dir = file.path(dir, "swc"), format = "swc", files = paste0(bodyids,".swc"), Force = TRUE)
   # save synapse locations
   if(connectors){
     message("saving synapse locations")

--- a/R/name.R
+++ b/R/name.R
@@ -126,7 +126,7 @@ neuprint_get_meta <- function(bodyids, dataset = NULL, all_segments = TRUE, conn
   all_segments = ifelse(all_segments,"Segment","Neuron")
 
   fieldNames <- neuprint_get_fields(possibleFields = c("bodyId","name","instance","type","status","statusLabel","pre","post","upstream","downstream","cropped",
-                                                       "size","cellBodyFiber"),
+                                                       "size","cellBodyFiber","synonyms"),
                                     dataset=dataset,conn=conn,...)
   returnCypher <- paste0("n.",fieldNames," AS ",dfFields(fieldNames),collapse=" , ")
   cypher = sprintf(
@@ -389,7 +389,7 @@ neuprint_get_fields <- function(possibleFields = c("bodyId", "pre", "post",
                                                    "status", "statusLabel",
                                                    "cropped", "instance", "name",
                                                    "size", "type", "cellBodyFiber",
-                                                   "somaLocation", "somaRadius"),
+                                                   "somaLocation", "somaRadius","synonyms"),
                                 negateFields=FALSE,
                                 dataset = NULL, conn = NULL, ...){
 
@@ -418,7 +418,8 @@ dfFields <- function(field_name) {
       "type",
       "cellBodyFiber",
       "somaLocation",
-      "somaRadius"
+      "somaRadius",
+      "synonyms"
     ),
     rName = c(
       "bodyid",
@@ -435,7 +436,8 @@ dfFields <- function(field_name) {
       "type",
       "cellBodyFiber",
       "somaLocation",
-      "somaRadius"
+      "somaRadius",
+      "synonyms"
     ),
     stringsAsFactors = FALSE
   )

--- a/R/roi.R
+++ b/R/roi.R
@@ -111,8 +111,7 @@ neuprint_bodies_in_ROI <- function(roi, dataset = NULL, all_segments = FALSE, co
 #' @export
 #' @examples
 #' \donttest{
-#' aba <- neuprint_ROI_connectivity(neuprint_ROIs(superLevel = TRUE),
-#'   full=FALSE)
+#' aba <- neuprint_ROI_connectivity(neuprint_ROIs(superLevel = TRUE),full=FALSE)
 #' heatmap(aba)
 #' }
 neuprint_ROI_connectivity <- function(rois, full=TRUE,

--- a/man/neuprint_ROI_connectivity.Rd
+++ b/man/neuprint_ROI_connectivity.Rd
@@ -50,8 +50,7 @@ When requesting summary connectivity data between ROIs, we recommend
 }
 \examples{
 \donttest{
-aba <- neuprint_ROI_connectivity(neuprint_ROIs(superLevel = TRUE),
-  full=FALSE)
+aba <- neuprint_ROI_connectivity(neuprint_ROIs(superLevel = TRUE),full=FALSE)
 heatmap(aba)
 }
 }

--- a/man/neuprint_get_adjacency_matrix.Rd
+++ b/man/neuprint_get_adjacency_matrix.Rd
@@ -57,10 +57,10 @@ Get an adjacency matrix for the synaptic connectivity within a
 \examples{
 \donttest{
 # these will mostly be axo-axonic connections between DA2 PNs
-neuprint_get_adjacency_matrix('DA2_lPN')
+neuprint_get_adjacency_matrix('DA2 lPN')
 
 # rectangular matrix with different in/out neurons
-neuprint_get_adjacency_matrix(inputids='DA2_lPN', outputids='DL4_adPN')
+neuprint_get_adjacency_matrix(inputids='DA2 lPN', outputids='DL4 adPN')
 }
 \donttest{
 # Note the use of cache=T, which will avoid a subsequent query to the

--- a/man/neuprint_get_adjacency_matrix.Rd
+++ b/man/neuprint_get_adjacency_matrix.Rd
@@ -57,10 +57,10 @@ Get an adjacency matrix for the synaptic connectivity within a
 \examples{
 \donttest{
 # these will mostly be axo-axonic connections between DA2 PNs
-neuprint_get_adjacency_matrix('DA2 lPN')
+neuprint_get_adjacency_matrix('DA2_lPN')
 
 # rectangular matrix with different in/out neurons
-neuprint_get_adjacency_matrix(inputids='DA2 lPN', outputids='DL4 adPN')
+neuprint_get_adjacency_matrix(inputids='DA2_lPN', outputids='DL4_adPN')
 }
 \donttest{
 # Note the use of cache=T, which will avoid a subsequent query to the

--- a/man/neuprint_get_fields.Rd
+++ b/man/neuprint_get_fields.Rd
@@ -7,7 +7,7 @@
 neuprint_get_fields(
   possibleFields = c("bodyId", "pre", "post", "upstream", "downstream", "status",
     "statusLabel", "cropped", "instance", "name", "size", "type", "cellBodyFiber",
-    "somaLocation", "somaRadius"),
+    "somaLocation", "somaRadius", "synonyms"),
   negateFields = FALSE,
   dataset = NULL,
   conn = NULL,

--- a/tests/testthat/test-name.R
+++ b/tests/testthat/test-name.R
@@ -27,7 +27,7 @@ test_that("test name searches ", {
   expect_named(mt,
                c(dfFields(neuprint_get_fields(possibleFields = c("bodyId","name","instance","type","status","statusLabel",
                                                                "pre","post","upstream","downstream","cropped",
-                                                               "size","cellBodyFiber"))),"soma")
+                                                               "size","cellBodyFiber","synonyms"))),"soma")
                )
 
 

--- a/tests/testthat/test-roi.R
+++ b/tests/testthat/test-roi.R
@@ -4,7 +4,7 @@ test_that("", {
   baseline <- structure(list(`AL(R).pre` = 1L, `AL(R).post` = 162L,
                              `LH(R).pre` = 20L, `LH(R).post` = 25L),
                         class = "data.frame", row.names = "1")
-  expect_equal(xdf <- extract_connectivity_df(rois = rois, json=json), baseline)
+  expect_equal(xdf <- extract_connectivity_df(rois = rois, json=json), tibble::as_tibble(baseline))
 })
 
 skip_if(as.logical(Sys.getenv("SKIP_NP_SERVER_TESTS")))


### PR DESCRIPTION
The upcoming 1.1 version of the database contains a `synonyms` field that stores alternate type names. This just adds it to the output of `neuprint_get_meta` if it exists