### PR TITLE
[ENH] neuprint_get_adjacency_matrix with neurotransmitters

### DIFF
--- a/R/connectivity.R
+++ b/R/connectivity.R
@@ -6,6 +6,8 @@
 #'   alternative to \code{bodyids})
 #' @param threshold Return only connections greater than or equal to the
 #'   indicated strength (default 1 returns all connections).
+#' @param neurotransmitter Return only connections with given neurotransmitter
+#' type.
 #' @param sparse Whether to return a sparse adjacency matrix (of class
 #'   \code{\link[=CsparseMatrix-class]{CsparseMatrix}}). This may be a
 #'   particularly good idea for large matrices of >5000 neurons, especially if a
@@ -58,6 +60,7 @@
 neuprint_get_adjacency_matrix <- function(bodyids=NULL, inputids=NULL,
                                           outputids=NULL,
                                           threshold=1L,
+                                          neurotransmitter=NULL,
                                           dataset = NULL,
                                           chunksize=1000L,
                                           all_segments = FALSE, conn = NULL,
@@ -110,8 +113,17 @@ neuprint_get_adjacency_matrix <- function(bodyids=NULL, inputids=NULL,
   all_segments.json = ifelse(all_segments,"Segment","Neuron")
   namefield=neuprint_name_field(conn=conn, dataset=dataset)
   checkmate::assertIntegerish(threshold, lower = 1, len = 1, any.missing = F)
+  if (!is.null(neurotransmitter)) {
+    checkmate::assertChoice(neurotransmitter, c("acetylcholine", "gaba", "glutamate"))
+    nt_filter <- glue(paste(
+      "MATCH (n:`{all_segments.json}`) WHERE n.{neurotransmitter} >= n.acetylcholine AND n.{neurotransmitter} >= n.gaba AND n.{neurotransmitter} >= n.glutamate AND n.{neurotransmitter} >= n.neither",
+      "MATCH (m:`{all_segments.json}`) WHERE m.{neurotransmitter} >= m.acetylcholine AND m.{neurotransmitter} >= m.gaba AND m.{neurotransmitter} >= m.glutamate AND m.{neurotransmitter} >= m.neither"
+    ))
+  } else
+    nt_filter <- ""
   cypher = glue(
     "WITH {id2json(inputids)} AS input, {id2json(outputids)} AS output",
+    nt_filter,
     "MATCH (n:`{all_segments.json}`)-[c:ConnectsTo]->(m)",
     "WHERE n.bodyId IN input AND m.bodyId IN output",
     ifelse(threshold>1, paste("AND c.weight>",threshold-1),""),

--- a/man/neuprint_get_adjacency_matrix.Rd
+++ b/man/neuprint_get_adjacency_matrix.Rd
@@ -9,6 +9,7 @@ neuprint_get_adjacency_matrix(
   inputids = NULL,
   outputids = NULL,
   threshold = 1L,
+  neurotransmitter = NULL,
   dataset = NULL,
   chunksize = 1000L,
   all_segments = FALSE,
@@ -27,6 +28,9 @@ alternative to \code{bodyids})}
 
 \item{threshold}{Return only connections greater than or equal to the
 indicated strength (default 1 returns all connections).}
+
+\item{neurotransmitter}{Return only connections with given neurotransmitter
+type.}
 
 \item{dataset}{optional, a dataset you want to query. If \code{NULL}, the
 default specified by your R environ file is used or, failing that the

--- a/tests/testthat/test-connectivity.R
+++ b/tests/testthat/test-connectivity.R
@@ -119,6 +119,8 @@ test_that("other connectivity functions work", {
   expect_equal(rownames(t1), rownames(t2))
   expect_true(length(t1)>0)
 
+  expect_error(neuprint_get_adjacency_matrix(bodyids = da2s$bodyid, neurotransmitter = "x")
+
   expect_is(t3 <- neuprint_simple_connectivity(da2s$bodyid[1], prepost='PRE'),
             'data.frame')
   pns11=neuprint_search('.*PN.*', meta=FALSE, all_segments = FALSE)[1:11]


### PR DESCRIPTION
New feature added. `neuprint_get_adjacency_matrix` can return now an adjacency matrix for a specific neurotransmitter.