### PR TITLE
Fix when dataset for connection not passed on

### DIFF
--- a/R/connectivity.R
+++ b/R/connectivity.R
@@ -291,7 +291,7 @@ neuprint_connection_table <- function(bodyids,
     prepost <- match.arg(prepost)
   }
   conn<-neuprint_login(conn)
-  dataset <- check_dataset(dataset)
+  dataset <- check_dataset(dataset, conn=conn)
   bodyids <- neuprint_ids(bodyids, dataset = dataset, conn = conn)
 
   threshold=assert_integer(as.integer(round(threshold)), lower = 1, len = 1)


### PR DESCRIPTION
* if you have a connection object with an associated dataset this should be used insted of the default dataset
* this is why check_dataset(dataset, conn=conn) is used in all other locations in the package
* this change fixes that omission in neuprint_connection_table