### PR TITLE
Fix bug when only presynapse is inside ROI

### DIFF
--- a/R/connectivity.R
+++ b/R/connectivity.R
@@ -359,7 +359,7 @@ neuprint_connection_table <- function(bodyids,
                  ifelse(prepost=="POST","bodyid","partner"),
                  ifelse(prepost=="POST","partner","bodyid"),
                  extrafields,
-                 ifelse(!is.null(roi)|by.roi,", k AS roi, apoc.convert.fromJsonMap(c.roiInfo)[k].post AS ROIweight","")
+                 ifelse(!is.null(roi)|by.roi,", k AS roi, coalesce(apoc.convert.fromJsonMap(c.roiInfo)[k].post,0) AS ROIweight","")
 
   )
   cypher <-paste(WITH, MATCH, WHERE, RETURN)


### PR DESCRIPTION
* noticed with neuprintr::neuprint_connection_table(11419, roi='AL(R)', conn=mcns_neuprint())

* details at https://flyem-cns.slack.com/archives/CDFV4R0KX/p1671552914470399?thread_ts=1671203277.649779&cid=CDFV4R0KX
* @mmc46 can you check this PR fixes the issue you had?