### PR TITLE
Better error message for missing search field

### DIFF
--- a/R/name.R
+++ b/R/name.R
@@ -331,6 +331,10 @@ neuprint_search <- function(search, field = "name", fixed=FALSE, exact=NULL,
     where=search
   } else {
     fieldtype=neuprint_typeof(field, type = 'neo4j', conn=conn, dataset = dataset)
+    if(length(fieldtype)==0) {
+      stop("Sorry, the `", field,
+           "` field doesn't exist in neuprint database (which is case-sensitive)!")
+    }
     if(fieldtype=="STRING") {
       search=glue('\\"{search}\\"')
       operator=ifelse(fixed, ifelse(exact, "=", "CONTAINS"), "=~")

--- a/tests/testthat/test-ids.R
+++ b/tests/testthat/test-ids.R
@@ -75,4 +75,6 @@ test_that("neuprint_ids works", {
   expect_true(all(neuprint_ids("!MBON01") %in% mbons))
   expect_equal(neuprint_ids("/MBON[0-9]+"),
                as.character(neuprint_search("type:MBON[0-9]+", meta=FALSE)))
+
+  expect_error(neuprint_ids('rhubarb:.+'), "rhubarb.*doesn't.*exist")
 })


### PR DESCRIPTION
previously something like this:
```
neuprintr::neuprint_ids('rhubarb:.+')
```

would have given
```
Error in if (fieldtype == "STRING") { : argument is of length zero
```

now:

```
Error in neuprint_search(x, meta = F, field = "type", fixed = fixed, conn = conn,  : 
  Sorry, the `rhubarb` field doesn't exist in neuprint database (which is case-sensitive)!
```