### PR TITLE
Preserve precision of large (>2^53) body ids in JSON responses

### DIFF
--- a/R/fetch.R
+++ b/R/fetch.R
@@ -75,7 +75,7 @@ neuprint_parse_json <- function (req, simplifyVector = FALSE, ...) {
   text <- httr::content(req, as = "text", encoding = "UTF-8")
   if (identical(text, ""))
     stop("No output to parse", call. = FALSE)
-  jsonlite::fromJSON(text, simplifyVector = simplifyVector, ...)
+  jsonlite::fromJSON(text, simplifyVector = simplifyVector, bigint_as_char = TRUE, ...)
 }
 
 # hidden


### PR DESCRIPTION
Use bigint_as_char=TRUE in neuprint_parse_json so that body ids exceeding the 53-bit mantissa of double-precision floats are returned as character strings rather than silently truncated. Downstream code (e.g. id2bit64) already handles character input correctly.